### PR TITLE
main: support find update in package directory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ use std::{
 };
 use version_compare::{compare_to, Cmp};
 
+
+
 mod checker;
 mod cli;
 mod parser;
@@ -33,13 +35,13 @@ struct CheckerResult {
 }
 
 fn collect_spec(dir: &Path) -> Result<Vec<PathBuf>> {
-    let walker = walkdir::WalkDir::new(dir).max_depth(3);
+    let walker = walkdir::WalkDir::new(dir).min_depth(1).max_depth(3);
     let result = walker
         .into_iter()
         .filter_map(|x| {
             let entry = x.ok()?;
             if entry.file_name() == "spec" {
-                Some(PathBuf::from(entry.path()))
+                entry.path().canonicalize().ok()
             } else {
                 None
             }
@@ -50,8 +52,8 @@ fn collect_spec(dir: &Path) -> Result<Vec<PathBuf>> {
 }
 
 fn normalize_name(path: &Path) -> Cow<str> {
-    let p = path.strip_prefix("./").unwrap_or(path);
-    let p = p.parent().unwrap_or(path);
+    let p = path.parent().unwrap_or(path);
+    let p = p.file_name().unwrap_or(p.as_os_str());
 
     p.to_string_lossy()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,6 @@ use std::{
 };
 use version_compare::{compare_to, Cmp};
 
-
-
 mod checker;
 mod cli;
 mod parser;


### PR DESCRIPTION
```
saki@66Mag [ telegram-desktop@stable ] $ pwd
/home/saki/aosc-os-abbs/extra-web/telegram-desktop
saki@66Mag [ telegram-desktop@stable ] $ ~/aosc-findupdate/target/debug/aosc-findupdate -i telegram-desktop
[2022-03-20T17:30:47Z INFO  aosc_findupdate] Checking updates for 1 packages ...
[2022-03-20T17:30:47Z INFO  aosc_findupdate] [1/1] Checking telegram-desktop ...
The following packages were updated:
Name                                            Version                                 Issues
telegram-desktop                             3.5.2 -> 3.6.1                             Hardcoded URLs detected.

Errors:
```