### PR TITLE
parse: fix "Unknown type" errors

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -56,7 +56,7 @@ pub(crate) fn parse_check_update(content: &mut &str) -> Result<Context> {
     let parsed = config_line(content).map_err(|err| anyhow!("Invalid config line: {}", err))?;
     let mut context = HashMap::new();
     let config = parsed.1;
-    context.insert("type".to_string(), content.to_string());
+    context.insert("type".to_string(), parsed.0.to_string());
 
     for (k, v) in config {
         context.insert(k.to_string(), v.to_string());


### PR DESCRIPTION
Appears to be broken since https://github.com/AOSC-Dev/aosc-findupdate/commit/e3d95d3b1ec8fa5a69f2c6727be4e63e829a3d63